### PR TITLE
fix 'Parse error' in Atom 1.9-1.10

### DIFF
--- a/autocomplete_service/code_completion_server.h
+++ b/autocomplete_service/code_completion_server.h
@@ -74,7 +74,8 @@ class CodeCompletionServer : public Object {
 			resp += "\r\n";
 			resp += p_body;
 
-			cd->connection->put_utf8_string(resp);
+			CharString utf = resp.utf8();
+			cd->connection->put_data((const uint8_t*)utf.get_data(), utf.length());
 		}
 
 		Request(ClientData *cd) {


### PR DESCRIPTION
node.js strict parse http headers now. 

And plugin stopped work, because godot add uint32 in front of response
https://github.com/godotengine/godot/blob/master/core/io/stream_peer.cpp#L225

Tested in latest Atom, Mac os.
